### PR TITLE
Grid stats: align vertical items

### DIFF
--- a/src/components/Blocks/GridStat/GridStat.js
+++ b/src/components/Blocks/GridStat/GridStat.js
@@ -19,7 +19,7 @@ function GridStat({ block }) {
         {text && <div className="text" dangerouslySetInnerHTML={{ __html: text }} />}
 
         {isArray(stats) && (
-          <div className="row justify-content-center gy-5">
+          <div className="row justify-content-center align-items-start gy-5">
             {stats.map((item, index) => (
               <div
                 className={`${isGridSizeGreaterThan3 ? 'col-lg-3' : 'col-lg-4'} col-md-4 col-sm-6 stat-item`}


### PR DESCRIPTION
Los items ahoran estan alineados verticalmente: 
![image](https://user-images.githubusercontent.com/112974289/219661631-f6eed795-cd1d-43c0-ac32-bc607ce1c5c8.png)

Antes se veia de la sig. manera:
![image](https://user-images.githubusercontent.com/112974289/219661731-e7e8e92e-aeff-4f62-89d0-0c5742e175a5.png)
